### PR TITLE
Add PPTX schedule extraction and Excel sync tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+.eggs/
+*.log
+.venv/
+.env
+pptx_versions.json
+version_state.json
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
 # ChatGPT_TWS
-TWS TrialRun
+
+工具可以自動從資料夾中的 `.pptx` 檔案擷取專案名稱與 SCHEDULE TABLE 的日期，並把整理後的資訊同步到線上 Excel。程式會同時維護一份版本紀錄檔，方便掌握每個專案更新的版本。
+
+## 安裝環境
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pip install pytest  # 執行測試時需要
+```
+
+## 使用方式
+
+執行 CLI 時需要提供 PPTX 資料夾路徑，以及目標 Excel（Microsoft Graph）相關資訊。Graph Access Token 可以透過 `--token` 參數提供，也可以預先設定在環境變數 `GRAPH_API_TOKEN`。
+
+```bash
+python -m pptx_schedule \
+  --pptx-dir ./presentations \
+  --drive-id <DRIVE_ID> \
+  --item-id <ITEM_ID> \
+  --worksheet Sheet1 \
+  --table ProjectSchedule \
+  --version-store ./pptx_versions.json \
+  --clear-before-update
+```
+
+常用參數說明：
+
+- `--recursive`：遞迴搜尋子資料夾內的 PPTX 檔案。
+- `--dry-run`：僅顯示將寫入 Excel 的內容，不會真的更新 Excel 或版本檔。
+- `--project-name-pattern` / `--project-name-keyword`：客製化專案名稱的擷取規則。
+- `--schedule-keyword`：指定判斷 SCHEDULE TABLE 的關鍵字。
+- `--dayfirst`：遇到模糊日期格式（例如 `10/11/2024`）時採用「日/月/年」解析。
+
+執行後會產生（或更新） `pptx_versions.json`，記錄每個專案最新的版本號與時間戳記。
+
+## 測試
+
+```bash
+pytest
+```

--- a/pptx_schedule/__init__.py
+++ b/pptx_schedule/__init__.py
@@ -1,0 +1,11 @@
+"""Utilities for extracting schedule information from PPTX files and syncing it to Excel."""
+
+from .models import ExtractionConfig, ExtractedProject, ScheduleEntry
+from .extractor import extract_project_info
+
+__all__ = [
+    "ExtractionConfig",
+    "ExtractedProject",
+    "ScheduleEntry",
+    "extract_project_info",
+]

--- a/pptx_schedule/__main__.py
+++ b/pptx_schedule/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for ``python -m pptx_schedule``."""
+
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover - module execution
+    raise SystemExit(main())

--- a/pptx_schedule/cli.py
+++ b/pptx_schedule/cli.py
@@ -1,0 +1,180 @@
+"""Command line interface that orchestrates PPTX extraction and Excel updates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Mapping, Sequence
+
+from .excel_client import ExcelUpdater, GraphExcelClient
+from .extractor import extract_project_info
+from .models import ExtractionConfig
+from .versioning import VersionManager
+
+DEFAULT_COLUMNS = [
+    "ProjectName",
+    "PptxPath",
+    "ScheduleDates",
+    "ScheduleCount",
+    "Version",
+    "UpdatedAt",
+]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Extract schedule information from PPTX files and update Excel.")
+    parser.add_argument("--pptx-dir", required=True, help="Directory that contains PPTX files to process.")
+    parser.add_argument(
+        "--token",
+        default=None,
+        help="Microsoft Graph access token. If omitted, GRAPH_API_TOKEN from the environment is used.",
+    )
+    parser.add_argument("--drive-id", help="Drive ID that stores the Excel workbook.")
+    parser.add_argument("--item-id", help="Item ID (file ID) of the Excel workbook.")
+    parser.add_argument("--worksheet", help="Target worksheet name in the workbook.")
+    parser.add_argument("--table", help="Target table name inside the worksheet.")
+    parser.add_argument(
+        "--column",
+        action="append",
+        dest="columns",
+        default=None,
+        help="Column name to export. Repeat for multiple columns. Defaults to a preset selection.",
+    )
+    parser.add_argument(
+        "--version-store",
+        default="pptx_versions.json",
+        help="Path to the JSON file that stores version information.",
+    )
+    parser.add_argument(
+        "--project-name-pattern",
+        action="append",
+        dest="project_name_patterns",
+        default=None,
+        help="Additional regular expression used to locate the project name.",
+    )
+    parser.add_argument(
+        "--project-name-keyword",
+        action="append",
+        dest="project_name_keywords",
+        default=None,
+        help="Additional keyword to search for the project name.",
+    )
+    parser.add_argument(
+        "--schedule-keyword",
+        action="append",
+        dest="schedule_keywords",
+        default=None,
+        help="Keyword that marks a table as containing schedule information.",
+    )
+    parser.add_argument(
+        "--dayfirst",
+        action="store_true",
+        help="Interpret ambiguous dates as day-first (e.g. 10/11/2024 -> 10 November).",
+    )
+    parser.add_argument(
+        "--clear-before-update",
+        action="store_true",
+        help="Clear the Excel table before inserting new rows.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Extract information without modifying Excel or the version store.",
+    )
+    parser.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Recursively search for PPTX files inside the provided directory.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    pptx_dir = Path(args.pptx_dir)
+    if not pptx_dir.exists():
+        parser.error(f"PPTX directory does not exist: {pptx_dir}")
+
+    base_config = ExtractionConfig(dayfirst=args.dayfirst)
+    config = ExtractionConfig(
+        project_name_patterns=args.project_name_patterns or base_config.project_name_patterns,
+        project_name_keywords=args.project_name_keywords or base_config.project_name_keywords,
+        schedule_table_keywords=args.schedule_keywords or base_config.schedule_table_keywords,
+        dayfirst=args.dayfirst,
+    )
+
+    pptx_paths = _discover_pptx_files(pptx_dir, recursive=args.recursive)
+    if not pptx_paths:
+        print("No PPTX files found. Nothing to do.")
+        return 0
+
+    version_manager = VersionManager(args.version_store)
+
+    token = args.token or os.getenv("GRAPH_API_TOKEN")
+    if not args.dry_run and not token:
+        parser.error("An access token is required unless running in dry-run mode.")
+
+    columns = args.columns or list(DEFAULT_COLUMNS)
+
+    client = None if args.dry_run else GraphExcelClient(token)
+    updater = ExcelUpdater(
+        client,
+        drive_id=args.drive_id or "",
+        item_id=args.item_id or "",
+        worksheet=args.worksheet or "",
+        table_name=args.table or "",
+        columns=columns,
+    )
+
+    records: List[Mapping[str, object]] = []
+    for pptx_path in pptx_paths:
+        project = extract_project_info(pptx_path, config=config)
+        schedule_dates = sorted({entry.value.isoformat() for entry in project.schedule_entries})
+        schedule_count = len(schedule_dates)
+
+        metadata = {"pptx_path": str(pptx_path), "schedule_count": schedule_count}
+        existing_version = version_manager.get(project.project_name)
+        if args.dry_run:
+            next_version = 1 if existing_version is None else existing_version.version + 1
+            updated_at = datetime.now(timezone.utc).isoformat()
+        else:
+            record = version_manager.bump(project.project_name, metadata=metadata)
+            next_version = record.version
+            updated_at = record.updated_at
+
+        record_map = {
+            "ProjectName": project.project_name,
+            "PptxPath": str(pptx_path),
+            "ScheduleDates": schedule_dates,
+            "ScheduleCount": schedule_count,
+            "Version": next_version,
+            "UpdatedAt": updated_at,
+        }
+        records.append(record_map)
+
+    rows = updater.push_records(
+        records,
+        clear_before_update=args.clear_before_update,
+        dry_run=args.dry_run,
+    )
+
+    if args.dry_run:
+        print("Dry run - the following rows would be sent to Excel:")
+        print(json.dumps({"columns": columns, "rows": rows}, ensure_ascii=False, indent=2))
+
+    print(f"Processed {len(records)} PPTX files.")
+    return 0
+
+
+def _discover_pptx_files(root: Path, *, recursive: bool) -> List[Path]:
+    pattern = "**/*.pptx" if recursive else "*.pptx"
+    return sorted(path for path in root.glob(pattern) if path.is_file())
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/pptx_schedule/excel_client.py
+++ b/pptx_schedule/excel_client.py
@@ -1,0 +1,139 @@
+"""Microsoft Graph Excel client helpers used to sync extracted data."""
+
+from __future__ import annotations
+
+import json
+from typing import Iterable, List, Mapping, Optional, Sequence
+
+import requests
+
+
+class ExcelUpdateError(RuntimeError):
+    """Raised when a Microsoft Graph API call related to Excel fails."""
+
+
+class GraphExcelClient:
+    """Small wrapper around the Microsoft Graph Excel API."""
+
+    def __init__(
+        self,
+        access_token: str,
+        *,
+        base_url: str = "https://graph.microsoft.com/v1.0",
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        if not access_token:
+            raise ValueError("An access token is required for Graph API calls.")
+        self._access_token = access_token
+        self._base_url = base_url.rstrip("/")
+        self._session = session or requests.Session()
+
+    def close(self) -> None:
+        self._session.close()
+
+    def clear_table(self, drive_id: str, item_id: str, worksheet: str, table_name: str) -> None:
+        """Remove the data contained in an Excel table."""
+
+        endpoint = self._table_endpoint(drive_id, item_id, worksheet, table_name, suffix="/range/clear")
+        self._request("POST", endpoint, json={"applyTo": "All"})
+
+    def add_rows(
+        self,
+        drive_id: str,
+        item_id: str,
+        worksheet: str,
+        table_name: str,
+        values: Sequence[Sequence[str]],
+    ) -> None:
+        """Append rows to an Excel table."""
+
+        if not values:
+            return
+        endpoint = self._table_endpoint(drive_id, item_id, worksheet, table_name, suffix="/rows/add")
+        payload = {"values": [list(row) for row in values]}
+        self._request("POST", endpoint, json=payload)
+
+    def _table_endpoint(
+        self, drive_id: str, item_id: str, worksheet: str, table_name: str, *, suffix: str = ""
+    ) -> str:
+        worksheet_part = f"workbook/worksheets('{worksheet}')"
+        table_part = f"tables('{table_name}')"
+        return f"{self._base_url}/drives/{drive_id}/items/{item_id}/{worksheet_part}/{table_part}{suffix}"
+
+    def _request(self, method: str, url: str, **kwargs) -> requests.Response:
+        headers = kwargs.pop("headers", {})
+        headers.setdefault("Authorization", f"Bearer {self._access_token}")
+        headers.setdefault("Content-Type", "application/json")
+        response = self._session.request(method, url, headers=headers, **kwargs)
+        if response.status_code >= 400:
+            message = self._format_error(response)
+            raise ExcelUpdateError(message)
+        return response
+
+    @staticmethod
+    def _format_error(response: requests.Response) -> str:
+        try:
+            payload = response.json()
+        except json.JSONDecodeError:
+            payload = response.text
+        return f"Graph API request failed ({response.status_code}): {payload}"
+
+
+class ExcelUpdater:
+    """High level helper that converts records into Excel table rows."""
+
+    def __init__(
+        self,
+        client: Optional[GraphExcelClient],
+        *,
+        drive_id: str,
+        item_id: str,
+        worksheet: str,
+        table_name: str,
+        columns: Sequence[str],
+    ) -> None:
+        if not columns:
+            raise ValueError("At least one column must be provided for Excel updates.")
+        self._client = client
+        self._drive_id = drive_id
+        self._item_id = item_id
+        self._worksheet = worksheet
+        self._table_name = table_name
+        self._columns = list(columns)
+
+    def push_records(
+        self,
+        records: Iterable[Mapping[str, object]],
+        *,
+        clear_before_update: bool = False,
+        dry_run: bool = False,
+    ) -> List[List[str]]:
+        """Push records into the configured Excel table and return serialized rows."""
+
+        rows: List[List[str]] = [self._serialize_record(record) for record in records]
+
+        if dry_run or self._client is None:
+            return rows
+
+        if clear_before_update:
+            self._client.clear_table(self._drive_id, self._item_id, self._worksheet, self._table_name)
+
+        if rows:
+            self._client.add_rows(
+                self._drive_id,
+                self._item_id,
+                self._worksheet,
+                self._table_name,
+                rows,
+            )
+        return rows
+
+    def _serialize_record(self, record: Mapping[str, object]) -> List[str]:
+        serialized: List[str] = []
+        for column in self._columns:
+            value = record.get(column, "")
+            if isinstance(value, (list, tuple, set)):
+                serialized.append(", ".join(sorted(str(item) for item in value)))
+            else:
+                serialized.append("" if value is None else str(value))
+        return serialized

--- a/pptx_schedule/extractor.py
+++ b/pptx_schedule/extractor.py
@@ -1,0 +1,201 @@
+"""Functions that parse PPTX presentations and extract scheduling information."""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+from pathlib import Path
+from typing import Iterator, List, Optional, Sequence, Tuple
+
+from dateutil import parser
+from pptx import Presentation
+from pptx.enum.shapes import MSO_SHAPE_TYPE
+
+from .models import ExtractionConfig, ExtractedProject, ScheduleEntry
+
+DATE_TOKEN_PATTERNS: Sequence[re.Pattern[str]] = (
+    re.compile(r"\b\d{4}[/-]\d{1,2}[/-]\d{1,2}\b"),
+    re.compile(r"\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b"),
+    re.compile(r"\b\d{1,2}[/-]\d{1,2}\b"),
+)
+CHINESE_DATE_PATTERN = re.compile(
+    r"(?P<year>\d{4})年(?P<month>\d{1,2})月(?P<day>\d{1,2})日"
+)
+
+
+def extract_project_info(
+    pptx_path: Path | str, config: Optional[ExtractionConfig] = None
+) -> ExtractedProject:
+    """Extract the project name and schedule entries from the provided PPTX file."""
+
+    cfg = config or ExtractionConfig()
+    path = Path(pptx_path)
+    if not path.exists():
+        raise FileNotFoundError(f"PPTX file not found: {path}")
+
+    presentation = Presentation(str(path))
+    texts: List[str] = []
+    schedule_entries: List[ScheduleEntry] = []
+    seen_entries: set[Tuple[int, date, str]] = set()
+
+    for slide_index, slide in enumerate(presentation.slides):
+        for text in _iter_slide_text(slide.shapes):
+            cleaned = _clean_text(text)
+            if cleaned:
+                texts.append(cleaned)
+
+        for table in _iter_slide_tables(slide.shapes):
+            if not _table_matches_keywords(table, cfg.schedule_table_keywords):
+                continue
+
+            for entry in _extract_schedule_entries_from_table(
+                table, slide_index=slide_index, dayfirst=cfg.dayfirst
+            ):
+                entry_key = (entry.slide_index, entry.value, entry.cell_text)
+                if entry_key not in seen_entries:
+                    seen_entries.add(entry_key)
+                    schedule_entries.append(entry)
+
+    project_name = _resolve_project_name(texts, cfg, fallback=path.stem)
+
+    return ExtractedProject(
+        project_name=project_name,
+        schedule_entries=schedule_entries,
+        source_path=path,
+    )
+
+
+def _iter_slide_text(shapes) -> Iterator[str]:
+    for shape in shapes:
+        yield from _iter_shape_text(shape)
+
+
+def _iter_shape_text(shape) -> Iterator[str]:
+    if getattr(shape, "has_text_frame", False):
+        yield shape.text
+    elif shape.shape_type == MSO_SHAPE_TYPE.GROUP:
+        for sub_shape in shape.shapes:  # type: ignore[attr-defined]
+            yield from _iter_shape_text(sub_shape)
+
+
+def _iter_slide_tables(shapes) -> Iterator:
+    for shape in shapes:
+        yield from _iter_shape_tables(shape)
+
+
+def _iter_shape_tables(shape) -> Iterator:
+    if getattr(shape, "has_table", False):
+        yield shape.table
+    elif shape.shape_type == MSO_SHAPE_TYPE.GROUP:
+        for sub_shape in shape.shapes:  # type: ignore[attr-defined]
+            yield from _iter_shape_tables(sub_shape)
+
+
+def _table_matches_keywords(table, keywords: Sequence[str]) -> bool:
+    if not keywords:
+        return True
+
+    joined = " ".join(
+        _clean_text(cell.text)
+        for row in table.rows
+        for cell in row.cells
+        if cell.text
+    )
+    haystack = joined.lower()
+    return any(keyword.lower() in haystack for keyword in keywords)
+
+
+def _extract_schedule_entries_from_table(table, *, slide_index: int, dayfirst: bool) -> Iterator[ScheduleEntry]:
+    for row in table.rows:
+        for cell in row.cells:
+            text = _clean_text(cell.text)
+            if not text:
+                continue
+            for value in _extract_dates_from_text(text, dayfirst=dayfirst):
+                yield ScheduleEntry(slide_index=slide_index, cell_text=text, value=value)
+
+
+def _extract_dates_from_text(text: str, *, dayfirst: bool) -> Iterator[date]:
+    seen: set[Tuple[int, int, int]] = set()
+    for pattern in DATE_TOKEN_PATTERNS:
+        for match in pattern.finditer(text):
+            candidate = match.group(0)
+            parsed = _parse_date(candidate, dayfirst=dayfirst)
+            if parsed:
+                key = (parsed.year, parsed.month, parsed.day)
+                if key not in seen:
+                    seen.add(key)
+                    yield parsed
+
+    for match in CHINESE_DATE_PATTERN.finditer(text):
+        year = int(match.group("year"))
+        month = int(match.group("month"))
+        day = int(match.group("day"))
+        key = (year, month, day)
+        if key not in seen:
+            seen.add(key)
+            yield date(year, month, day)
+
+
+def _parse_date(candidate: str, *, dayfirst: bool) -> Optional[date]:
+    try:
+        parsed = parser.parse(candidate, fuzzy=False, dayfirst=dayfirst)
+    except (ValueError, OverflowError):
+        return None
+    return parsed.date()
+
+
+def _resolve_project_name(
+    texts: Sequence[str], config: ExtractionConfig, *, fallback: str
+) -> str:
+    patterns = [re.compile(pattern, re.IGNORECASE) for pattern in config.project_name_patterns]
+
+    for text in texts:
+        for pattern in patterns:
+            match = pattern.search(text)
+            if match:
+                value = match.groupdict().get("value")
+                if value is None and match.groups():
+                    value = match.group(match.lastindex or 0)
+                if value:
+                    cleaned = _normalize_name(value)
+                    if cleaned:
+                        return cleaned
+
+    for text in texts:
+        lowered = text.lower()
+        for keyword in config.project_name_keywords:
+            keyword_lower = keyword.lower()
+            if keyword_lower in lowered:
+                extracted = _strip_keyword(text, keyword_lower)
+                if extracted:
+                    return extracted
+
+    for text in texts:
+        cleaned = _normalize_name(text)
+        if cleaned:
+            return cleaned
+
+    return _normalize_name(fallback) or fallback
+
+
+def _strip_keyword(text: str, keyword_lower: str) -> Optional[str]:
+    lowered = text.lower()
+    index = lowered.find(keyword_lower)
+    if index < 0:
+        return None
+    result = text[index + len(keyword_lower) :]
+    result = result.lstrip(" :：-\n\t")
+    return _normalize_name(result)
+
+
+def _normalize_name(value: str) -> str:
+    cleaned = _clean_text(value)
+    return cleaned
+
+
+def _clean_text(value: str | None) -> str:
+    if not value:
+        return ""
+    collapsed = re.sub(r"\s+", " ", value)
+    return collapsed.strip(" \n\t:\uff1a")

--- a/pptx_schedule/models.py
+++ b/pptx_schedule/models.py
@@ -1,0 +1,56 @@
+"""Data models used by the PPTX schedule extractor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+
+@dataclass
+class ScheduleEntry:
+    """Represents a single date found inside a schedule table."""
+
+    slide_index: int
+    cell_text: str
+    value: date
+
+
+@dataclass
+class ExtractedProject:
+    """Container for the information extracted from a PPTX presentation."""
+
+    project_name: str
+    schedule_entries: List[ScheduleEntry]
+    source_path: Path
+
+
+@dataclass
+class ExtractionConfig:
+    """Configuration options that control the extraction heuristics."""
+
+    project_name_patterns: Sequence[str] = field(
+        default_factory=lambda: [
+            r"專案名稱[:：]\s*(?P<value>.+)",
+            r"Project\s*Name[:：]\s*(?P<value>.+)",
+        ]
+    )
+    project_name_keywords: Sequence[str] = field(
+        default_factory=lambda: ["專案名稱", "project name", "project"]
+    )
+    schedule_table_keywords: Sequence[str] = field(
+        default_factory=lambda: ["schedule", "日期", "timeline", "milestone"]
+    )
+    dayfirst: bool = False
+
+    def extend_patterns(self, patterns: Iterable[str]) -> "ExtractionConfig":
+        """Return a copy of the config with additional project name patterns."""
+
+        merged = list(self.project_name_patterns) + list(patterns)
+        return ExtractionConfig(
+            project_name_patterns=merged,
+            project_name_keywords=self.project_name_keywords,
+            schedule_table_keywords=self.schedule_table_keywords,
+            dayfirst=self.dayfirst,
+        )

--- a/pptx_schedule/versioning.py
+++ b/pptx_schedule/versioning.py
@@ -1,0 +1,90 @@
+"""Simple JSON based version control helper for PPTX extraction runs."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Mapping, Optional
+
+
+@dataclass
+class VersionRecord:
+    """Holds the version number and last update timestamp for a project."""
+
+    version: int
+    updated_at: str
+    metadata: Mapping[str, object]
+
+
+class VersionManager:
+    """Persist versions for projects between runs of the synchronisation script."""
+
+    def __init__(self, storage_path: Path | str) -> None:
+        self._path = Path(storage_path)
+        self._state: Dict[str, VersionRecord] = {}
+        self._load()
+
+    def bump(self, project_name: str, metadata: Optional[Mapping[str, object]] = None) -> VersionRecord:
+        """Increase the stored version for ``project_name`` and persist the result."""
+
+        record = self._state.get(project_name)
+        next_version = 1 if record is None else record.version + 1
+        timestamp = datetime.now(timezone.utc).isoformat()
+        record_metadata: Mapping[str, object] = metadata or {}
+        new_record = VersionRecord(version=next_version, updated_at=timestamp, metadata=record_metadata)
+        self._state[project_name] = new_record
+        self._save()
+        return new_record
+
+    def get(self, project_name: str) -> Optional[VersionRecord]:
+        return self._state.get(project_name)
+
+    def reset(self, project_name: str) -> None:
+        if project_name in self._state:
+            del self._state[project_name]
+            self._save()
+
+    def snapshot(self) -> Mapping[str, VersionRecord]:
+        return dict(self._state)
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            self._state = {}
+            return
+
+        try:
+            payload = json.loads(self._path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON in version file {self._path}: {exc}") from exc
+
+        projects = payload.get("projects", {}) if isinstance(payload, dict) else {}
+        state: Dict[str, VersionRecord] = {}
+        for name, raw in projects.items():
+            if not isinstance(raw, dict):
+                continue
+            version = int(raw.get("version", 0))
+            updated_at = str(raw.get("updated_at", ""))
+            metadata = raw.get("metadata", {})
+            if not isinstance(metadata, Mapping):
+                metadata = {}
+            state[name] = VersionRecord(version=version, updated_at=updated_at, metadata=dict(metadata))
+        self._state = state
+
+    def _save(self) -> None:
+        if not self._path.parent.exists():
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "projects": {
+                name: {
+                    "version": record.version,
+                    "updated_at": record.updated_at,
+                    "metadata": dict(record.metadata),
+                }
+                for name, record in self._state.items()
+            }
+        }
+        temp_path = self._path.with_suffix(self._path.suffix + ".tmp")
+        temp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        temp_path.replace(self._path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+python-pptx>=0.6.21
+python-dateutil>=2.8.2
+requests>=2.31.0
+openpyxl>=3.1.2

--- a/tests/test_excel_client.py
+++ b/tests/test_excel_client.py
@@ -1,0 +1,69 @@
+from unittest.mock import Mock
+
+from pptx_schedule.excel_client import ExcelUpdater, GraphExcelClient
+
+
+class DummyResponse:
+    def __init__(self, status_code: int = 200, payload: object | None = None) -> None:
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = str(self._payload)
+
+    def json(self) -> object:
+        return self._payload
+
+
+def test_graph_excel_client_add_rows_builds_request() -> None:
+    session = Mock()
+    session.request.return_value = DummyResponse()
+    client = GraphExcelClient("token", session=session)
+
+    client.add_rows("drive", "item", "Sheet1", "Table1", [["foo", "bar"]])
+
+    session.request.assert_called_once()
+    method, url = session.request.call_args[0][:2]
+    kwargs = session.request.call_args.kwargs
+    assert method == "POST"
+    assert url.endswith("/tables('Table1')/rows/add")
+    assert kwargs["headers"]["Authorization"] == "Bearer token"
+    assert kwargs["json"] == {"values": [["foo", "bar"]]}
+
+
+def test_excel_updater_dry_run_returns_serialized_rows() -> None:
+    updater = ExcelUpdater(
+        None,
+        drive_id="drive",
+        item_id="item",
+        worksheet="Sheet1",
+        table_name="Table1",
+        columns=["Name", "Dates"],
+    )
+
+    rows = updater.push_records(
+        [{"Name": "Project", "Dates": ["2024-05-01", "2024-05-02"]}], dry_run=True
+    )
+
+    assert rows == [["Project", "2024-05-01, 2024-05-02"]]
+
+
+def test_excel_updater_invokes_client_when_not_dry_run() -> None:
+    client = Mock(spec=GraphExcelClient)
+    updater = ExcelUpdater(
+        client,
+        drive_id="drive",
+        item_id="item",
+        worksheet="Sheet1",
+        table_name="Table1",
+        columns=["Name"],
+    )
+
+    updater.push_records([{"Name": "Project"}], clear_before_update=True, dry_run=False)
+
+    client.clear_table.assert_called_once_with("drive", "item", "Sheet1", "Table1")
+    client.add_rows.assert_called_once_with(
+        "drive",
+        "item",
+        "Sheet1",
+        "Table1",
+        [["Project"]],
+    )

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,48 @@
+from datetime import date
+from pathlib import Path
+from pptx import Presentation
+
+from pptx_schedule import ExtractionConfig, extract_project_info
+
+
+def _create_sample_pptx(path: Path) -> None:
+    presentation = Presentation()
+    blank_slide_layout = presentation.slide_layouts[6]
+    slide = presentation.slides.add_slide(blank_slide_layout)
+
+    textbox = slide.shapes.add_textbox(left=100000, top=100000, width=4000000, height=500000)
+    textbox.text = "專案名稱: 測試專案"
+
+    rows, cols = 3, 2
+    table_shape = slide.shapes.add_table(rows, cols, left=100000, top=1500000, width=5000000, height=2000000)
+    table = table_shape.table
+    table.cell(0, 0).text = "Schedule"
+    table.cell(0, 1).text = "Item"
+    table.cell(1, 0).text = "2024/05/01"
+    table.cell(1, 1).text = "Kickoff"
+    table.cell(2, 0).text = "2024年05月10日"
+    table.cell(2, 1).text = "Review"
+
+    presentation.save(path)
+
+
+def test_extract_project_info(tmp_path: Path) -> None:
+    pptx_path = tmp_path / "demo.pptx"
+    _create_sample_pptx(pptx_path)
+
+    result = extract_project_info(pptx_path)
+
+    assert result.project_name == "測試專案"
+    dates = sorted(entry.value for entry in result.schedule_entries)
+    assert dates == [date(2024, 5, 1), date(2024, 5, 10)]
+
+
+def test_fallback_to_filename(tmp_path: Path) -> None:
+    pptx_path = tmp_path / "no_text.pptx"
+    presentation = Presentation()
+    presentation.slides.add_slide(presentation.slide_layouts[6])
+    presentation.save(pptx_path)
+
+    result = extract_project_info(pptx_path, config=ExtractionConfig(project_name_patterns=[]))
+    assert result.project_name == "no_text"
+    assert result.schedule_entries == []

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import pytest
+
+from pptx_schedule.versioning import VersionManager
+
+
+def test_version_manager_bump_and_persist(tmp_path: Path) -> None:
+    store = tmp_path / "versions.json"
+    manager = VersionManager(store)
+
+    record1 = manager.bump("ProjectA", metadata={"pptx_path": "demo.pptx"})
+    assert record1.version == 1
+
+    record2 = manager.bump("ProjectA")
+    assert record2.version == 2
+
+    manager_again = VersionManager(store)
+    restored = manager_again.get("ProjectA")
+    assert restored is not None
+    assert restored.version == 2
+    assert restored.metadata.get("pptx_path") == "demo.pptx"
+
+
+def test_version_manager_invalid_json(tmp_path: Path) -> None:
+    store = tmp_path / "versions.json"
+    store.write_text("not json", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        VersionManager(store)


### PR DESCRIPTION
## Summary
- implement PPTX parsing utilities to detect project names and schedule table dates
- add a command line interface that syncs extracted data to a Microsoft Graph Excel table with dry-run support and JSON-based version tracking
- provide unit tests and documentation covering extraction, Excel integration, version management, and usage instructions

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pptx' because python-pptx/dateutil dependencies cannot be installed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d103c633d083318a8413de796c2729