### PR TITLE
Add Common Travel Budget SPA with SharePoint Excel load and TSV copy

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,408 @@
+const STORAGE_KEY = "travelBudgetRecords";
+const TOTAL_DAYS = 28;
+
+const mappingData = [
+  { t1: "Corporate", t2: "Finance", t3: "Budget" },
+  { t1: "Corporate", t2: "Finance", t3: "Compliance" },
+  { t1: "Corporate", t2: "HR", t3: "Recruiting" },
+  { t1: "Corporate", t2: "HR", t3: "People Ops" },
+  { t1: "Engineering", t2: "Platform", t3: "Core" },
+  { t1: "Engineering", t2: "Platform", t3: "Infrastructure" },
+  { t1: "Engineering", t2: "Product", t3: "Frontend" },
+  { t1: "Engineering", t2: "Product", t3: "Backend" },
+  { t1: "Sales", t2: "APAC", t3: "Taiwan" },
+  { t1: "Sales", t2: "APAC", t3: "Japan" },
+  { t1: "Sales", t2: "EMEA", t3: "Germany" },
+  { t1: "Sales", t2: "EMEA", t3: "France" },
+];
+
+const dom = {
+  totalDays: document.getElementById("totalDays"),
+  usedDays: document.getElementById("usedDays"),
+  remainingDays: document.getElementById("remainingDays"),
+  remainingDaysWrap: document.getElementById("remainingDaysWrap"),
+  lastUpdated: document.getElementById("lastUpdated"),
+  summaryMessage: document.getElementById("summaryMessage"),
+  form: document.getElementById("recordForm"),
+  formError: document.getElementById("formError"),
+  applicant: document.getElementById("applicant"),
+  location: document.getElementById("location"),
+  days: document.getElementById("days"),
+  t1: document.getElementById("t1"),
+  t2: document.getElementById("t2"),
+  t3: document.getElementById("t3"),
+  daysMinus: document.getElementById("daysMinus"),
+  daysPlus: document.getElementById("daysPlus"),
+  applicantError: document.getElementById("applicantError"),
+  locationError: document.getElementById("locationError"),
+  daysError: document.getElementById("daysError"),
+  t1Error: document.getElementById("t1Error"),
+  recordsBody: document.getElementById("recordsBody"),
+  emptyState: document.getElementById("emptyState"),
+  copyAllBtn: document.getElementById("copyAllBtn"),
+  toast: document.getElementById("toast"),
+  loadExcelBtn: document.getElementById("loadExcelBtn"),
+};
+
+let records = [];
+
+const showToast = (message) => {
+  dom.toast.textContent = message;
+  dom.toast.classList.add("show");
+  window.setTimeout(() => dom.toast.classList.remove("show"), 2500);
+};
+
+const getNowIso = () => new Date().toISOString();
+
+const sortRecords = (list) =>
+  [...list].sort((a, b) => {
+    if (a.submitted_at === b.submitted_at) {
+      return a.applicant.localeCompare(b.applicant, "zh-Hant");
+    }
+    return b.submitted_at.localeCompare(a.submitted_at);
+  });
+
+const persistRecords = () => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(records));
+};
+
+const loadRecords = () => {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored) {
+    try {
+      records = JSON.parse(stored);
+    } catch (error) {
+      records = [];
+    }
+  }
+};
+
+const updateSummary = () => {
+  const usedDays = records.reduce((sum, item) => sum + Number(item.days || 0), 0);
+  const remaining = Math.max(TOTAL_DAYS - usedDays, 0);
+  const lastUpdated = records.length
+    ? sortRecords(records)[0].submitted_at
+    : "-";
+
+  dom.totalDays.textContent = TOTAL_DAYS;
+  dom.usedDays.textContent = usedDays;
+  dom.remainingDays.textContent = remaining;
+  dom.remainingDaysWrap.classList.toggle("warning", remaining === 0);
+  dom.lastUpdated.textContent = lastUpdated;
+  dom.summaryMessage.textContent = records.length
+    ? ""
+    : "尚未有任何申請，可直接在下方表單新增。";
+};
+
+const buildOptions = (select, values, placeholder) => {
+  select.innerHTML = "";
+  if (placeholder !== null) {
+    const option = document.createElement("option");
+    option.value = "";
+    option.textContent = placeholder;
+    select.appendChild(option);
+  }
+  values.forEach((value) => {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = value;
+    select.appendChild(option);
+  });
+};
+
+const updateT1Options = () => {
+  const t1Values = [...new Set(mappingData.map((item) => item.t1))];
+  buildOptions(dom.t1, t1Values, "請選擇");
+};
+
+const updateT2Options = (t1Value) => {
+  const t2Values = mappingData
+    .filter((item) => item.t1 === t1Value)
+    .map((item) => item.t2)
+    .filter((value) => value);
+  const unique = [...new Set(t2Values)];
+  buildOptions(dom.t2, unique, "（空白 / HQ）");
+  dom.t2.value = "";
+  updateT3Options("", "");
+};
+
+const updateT3Options = (t1Value, t2Value) => {
+  const t3Values = mappingData
+    .filter((item) => item.t1 === t1Value && item.t2 === t2Value)
+    .map((item) => item.t3)
+    .filter((value) => value);
+  const unique = [...new Set(t3Values)];
+  dom.t3.disabled = !t2Value;
+  const placeholder = t2Value ? "請選擇" : "請先選擇 T2";
+  buildOptions(dom.t3, unique, placeholder);
+  dom.t3.value = "";
+};
+
+const renderRecords = () => {
+  const sorted = sortRecords(records);
+  dom.recordsBody.innerHTML = "";
+  if (!sorted.length) {
+    dom.emptyState.style.display = "block";
+    return;
+  }
+  dom.emptyState.style.display = "none";
+  sorted.forEach((record) => {
+    const row = document.createElement("tr");
+    [
+      record.applicant,
+      record.location,
+      record.days,
+      record.t1,
+      record.t2,
+      record.t3,
+      record.submitted_at,
+      record.status,
+    ].forEach((value) => {
+      const cell = document.createElement("td");
+      cell.textContent = value || "";
+      row.appendChild(cell);
+    });
+    dom.recordsBody.appendChild(row);
+  });
+};
+
+const resetErrors = () => {
+  dom.formError.textContent = "";
+  dom.applicantError.textContent = "";
+  dom.locationError.textContent = "";
+  dom.daysError.textContent = "";
+  dom.t1Error.textContent = "";
+};
+
+const resetForm = () => {
+  dom.applicant.value = "";
+  dom.location.value = "";
+  dom.days.value = "1";
+  dom.t1.value = "";
+  updateT2Options("");
+};
+
+const validateDays = (value) => {
+  const numberValue = Number(value);
+  if (!Number.isInteger(numberValue) || numberValue < 1) {
+    return "天數必須為大於等於 1 的整數";
+  }
+  return "";
+};
+
+const validateForm = () => {
+  resetErrors();
+  let hasError = false;
+
+  if (!dom.applicant.value.trim()) {
+    dom.applicantError.textContent = "此欄位必填";
+    hasError = true;
+  }
+
+  if (!dom.location.value.trim()) {
+    dom.locationError.textContent = "此欄位必填";
+    hasError = true;
+  }
+
+  if (!dom.t1.value) {
+    dom.t1Error.textContent = "請選擇一級組織";
+    hasError = true;
+  }
+
+  const daysError = validateDays(dom.days.value);
+  if (daysError) {
+    dom.daysError.textContent = daysError;
+    hasError = true;
+  }
+
+  if (hasError) {
+    dom.formError.textContent = "請修正欄位錯誤後再送出";
+  }
+
+  return !hasError;
+};
+
+const isOverBudget = (newDays) => {
+  const usedDays = records.reduce((sum, item) => sum + Number(item.days || 0), 0);
+  return usedDays + newDays > TOTAL_DAYS;
+};
+
+const addRecord = () => {
+  const record = {
+    applicant: dom.applicant.value.trim(),
+    location: dom.location.value.trim(),
+    days: Number(dom.days.value),
+    t1: dom.t1.value,
+    t2: dom.t2.value,
+    t3: dom.t3.value,
+    submitted_at: getNowIso(),
+    status: "",
+  };
+
+  records.push(record);
+  persistRecords();
+  updateSummary();
+  renderRecords();
+  resetForm();
+  showToast("新增成功");
+};
+
+const handleSubmit = (event) => {
+  event.preventDefault();
+  if (!validateForm()) {
+    return;
+  }
+
+  const dayValue = Number(dom.days.value);
+  if (isOverBudget(dayValue)) {
+    dom.formError.textContent =
+      "剩餘天數不足，無法送出（將超出總預算天數）";
+    return;
+  }
+
+  addRecord();
+};
+
+const handleCopyAll = async () => {
+  const headers = [
+    "applicant",
+    "location",
+    "days",
+    "t1",
+    "t2",
+    "t3",
+    "submitted_at",
+    "status",
+  ];
+  const sorted = sortRecords(records);
+  const rows = sorted.map((record) =>
+    headers.map((header) => record[header] || "").join("\t")
+  );
+  const content = [headers.join("\t"), ...rows].join("\n");
+
+  try {
+    await navigator.clipboard.writeText(content);
+    showToast("已複製到剪貼簿");
+  } catch (error) {
+    showToast("複製失敗，請重試");
+  }
+};
+
+const applyExcelRecords = (items, sourceMessage) => {
+  records = items.map((item) => ({
+    applicant: item.applicant || "",
+    location: item.location || "",
+    days: Number(item.days) || 0,
+    t1: item.t1 || "",
+    t2: item.t2 || "",
+    t3: item.t3 || "",
+    submitted_at: item.submitted_at || getNowIso(),
+    status: item.status || "",
+  }));
+  persistRecords();
+  updateSummary();
+  renderRecords();
+  showToast(sourceMessage);
+};
+
+const loadFromSharePointExcel = async () => {
+  if (!window.msal || !window.sharePointConfig) {
+    showToast("SharePoint Excel 未設定或授權");
+    return;
+  }
+
+  const config = window.sharePointConfig;
+  const msalInstance = new msal.PublicClientApplication({
+    auth: {
+      clientId: config.clientId,
+      authority: `https://login.microsoftonline.com/${config.tenantId}`,
+      redirectUri: config.redirectUri || window.location.origin,
+    },
+  });
+
+  const loginResponse = await msalInstance.loginPopup({
+    scopes: ["User.Read", "Sites.Read.All"],
+  });
+
+  const tokenResponse = await msalInstance.acquireTokenSilent({
+    scopes: ["Sites.Read.All"],
+    account: loginResponse.account,
+  });
+
+  const tableEndpoint = `https://graph.microsoft.com/v1.0/sites/${config.siteId}/drive/root:/${config.excelPath}:/workbook/tables/${config.tableName}/rows`;
+  const response = await fetch(tableEndpoint, {
+    headers: {
+      Authorization: `Bearer ${tokenResponse.accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error("Unable to load SharePoint Excel");
+  }
+
+  const payload = await response.json();
+  const rows = payload.value || [];
+  const items = rows.map((row) => {
+    const [
+      applicant,
+      location,
+      days,
+      t1,
+      t2,
+      t3,
+      submitted_at,
+      status,
+    ] = row.values[0];
+    return {
+      applicant,
+      location,
+      days,
+      t1,
+      t2,
+      t3,
+      submitted_at,
+      status,
+    };
+  });
+
+  applyExcelRecords(items, `已從 SharePoint Excel 載入 ${items.length} 筆紀錄`);
+};
+
+const handleLoadExcel = async () => {
+  try {
+    await loadFromSharePointExcel();
+  } catch (error) {
+    showToast("SharePoint Excel 載入失敗，請重試");
+  }
+};
+
+const bindEvents = () => {
+  dom.form.addEventListener("submit", handleSubmit);
+  dom.daysMinus.addEventListener("click", () => {
+    const value = Math.max(Number(dom.days.value) - 1, 1);
+    dom.days.value = String(value);
+  });
+  dom.daysPlus.addEventListener("click", () => {
+    const value = Number(dom.days.value) + 1;
+    dom.days.value = String(value);
+  });
+  dom.t1.addEventListener("change", (event) => {
+    updateT2Options(event.target.value);
+  });
+  dom.t2.addEventListener("change", (event) => {
+    updateT3Options(dom.t1.value, event.target.value);
+  });
+  dom.copyAllBtn.addEventListener("click", handleCopyAll);
+  dom.loadExcelBtn.addEventListener("click", handleLoadExcel);
+};
+
+const init = () => {
+  updateT1Options();
+  updateT2Options("");
+  loadRecords();
+  updateSummary();
+  renderRecords();
+  bindEvents();
+};
+
+init();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Common Travel Budget</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header class="page-header">
+        <div>
+          <h1>Common Travel Budget</h1>
+          <p>單頁式出差預算控管工具</p>
+        </div>
+        <div class="header-actions">
+          <button id="loadExcelBtn" class="secondary">Load from SharePoint Excel</button>
+          <button id="copyAllBtn">Copy All</button>
+        </div>
+      </header>
+
+      <section class="summary-card">
+        <h2>Summary</h2>
+        <div class="summary-grid">
+          <div class="summary-item">
+            <span class="label">Total Days</span>
+            <span id="totalDays" class="value">0</span>
+          </div>
+          <div class="summary-item">
+            <span class="label">Used Days</span>
+            <span id="usedDays" class="value">0</span>
+          </div>
+          <div class="summary-item" id="remainingDaysWrap">
+            <span class="label">Remaining Days</span>
+            <span id="remainingDays" class="value">0</span>
+          </div>
+          <div class="summary-item">
+            <span class="label">Last updated</span>
+            <span id="lastUpdated" class="value">-</span>
+          </div>
+        </div>
+        <p id="summaryMessage" class="hint"></p>
+      </section>
+
+      <section class="form-card">
+        <h2>新增申請</h2>
+        <p id="formError" class="form-error"></p>
+        <form id="recordForm" novalidate>
+          <div class="form-grid">
+            <label>
+              出差人名 applicant
+              <input type="text" id="applicant" />
+              <span class="field-error" id="applicantError"></span>
+            </label>
+            <label>
+              出差地點 location
+              <input type="text" id="location" />
+              <span class="field-error" id="locationError"></span>
+            </label>
+            <label>
+              出差天數 days
+              <div class="stepper">
+                <button type="button" id="daysMinus">-</button>
+                <input type="number" id="days" min="1" step="1" value="1" />
+                <button type="button" id="daysPlus">+</button>
+              </div>
+              <span class="field-error" id="daysError"></span>
+            </label>
+            <label>
+              一級組織 T1
+              <select id="t1">
+                <option value="">請選擇</option>
+              </select>
+              <span class="field-error" id="t1Error"></span>
+            </label>
+            <label>
+              二級組織 T2
+              <select id="t2">
+                <option value="">（空白 / HQ）</option>
+              </select>
+              <span class="field-error" id="t2Error"></span>
+            </label>
+            <label>
+              三級組織 T3
+              <select id="t3" disabled>
+                <option value="">請先選擇 T2</option>
+              </select>
+              <span class="field-error" id="t3Error"></span>
+            </label>
+          </div>
+          <div class="form-actions">
+            <button type="submit">Submit</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="table-card">
+        <h2>Dashboard Records</h2>
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>applicant</th>
+                <th>location</th>
+                <th>days</th>
+                <th>t1</th>
+                <th>t2</th>
+                <th>t3</th>
+                <th>submitted_at</th>
+                <th>status</th>
+              </tr>
+            </thead>
+            <tbody id="recordsBody"></tbody>
+          </table>
+        </div>
+        <p id="emptyState" class="empty-state">目前尚無紀錄</p>
+      </section>
+    </main>
+
+    <div id="toast" class="toast" role="status"></div>
+
+    <script src="https://alcdn.msauth.net/browser/2.37.0/js/msal-browser.min.js"></script>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,213 @@
+:root {
+  color-scheme: light;
+  font-family: "Segoe UI", "Noto Sans", sans-serif;
+  background: #f5f7fb;
+  color: #1c2431;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 32px 20px 60px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.page-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.page-header h1 {
+  margin: 0 0 6px;
+  font-size: 28px;
+}
+
+.page-header p {
+  margin: 0;
+  color: #526074;
+}
+
+.header-actions {
+  display: flex;
+  gap: 12px;
+}
+
+button {
+  border: none;
+  border-radius: 8px;
+  padding: 10px 16px;
+  font-weight: 600;
+  cursor: pointer;
+  background: #2463eb;
+  color: #fff;
+}
+
+button.secondary {
+  background: #eef2ff;
+  color: #2463eb;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+summary {
+  display: contents;
+}
+
+.summary-card,
+.form-card,
+.table-card {
+  background: #fff;
+  border-radius: 16px;
+  padding: 20px 24px;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.summary-item {
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: #f1f4ff;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.summary-item .label {
+  font-size: 13px;
+  color: #4a5568;
+}
+
+.summary-item .value {
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.summary-item.warning {
+  background: #fff1f1;
+  color: #b42318;
+}
+
+.hint {
+  margin-top: 12px;
+  color: #4a5568;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 16px;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-weight: 600;
+  color: #1f2a44;
+}
+
+input,
+select {
+  border-radius: 8px;
+  border: 1px solid #d1d9e6;
+  padding: 8px 10px;
+  font-size: 14px;
+}
+
+.stepper {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.stepper button {
+  padding: 8px 12px;
+}
+
+.field-error {
+  color: #b42318;
+  font-weight: 500;
+  min-height: 18px;
+}
+
+.form-error {
+  color: #b42318;
+  font-weight: 600;
+  margin: 0 0 12px;
+  min-height: 20px;
+}
+
+.form-actions {
+  margin-top: 16px;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.table-card table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.table-card th,
+.table-card td {
+  padding: 10px 12px;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+}
+
+.empty-state {
+  margin-top: 12px;
+  color: #718096;
+}
+
+.toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  background: #1f2937;
+  color: #fff;
+  padding: 10px 16px;
+  border-radius: 12px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.toast.show {
+  opacity: 1;
+}
+
+@media (max-width: 640px) {
+  .header-actions {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
### Motivation
- Implement a single-page app to manage shared travel budget records with instant summary, form entry, dashboard table, one-click TSV copy, and optional SharePoint Excel import.
- Provide an offline-friendly experience using `localStorage` and a front-end-only import path (MSAL + Microsoft Graph) for SharePoint Excel as an opt-in feature.

### Description
- Add `index.html` to provide the SPA layout with Summary, Form, Dashboard Records table, `Copy All` and `Load from SharePoint Excel` actions.
- Add `styles.css` for SharePoint-friendly styling of the summary, form, table, stepper, and toast notifications.
- Add `app.js` implementing records state, `localStorage` persistence, form validation messages, T1/T2/T3 cascading dropdown logic from `mappingData`, deterministic sorting (`submitted_at` DESC then `applicant` ASC), budget enforcement against `TOTAL_DAYS`, TSV `Copy All` to clipboard, and MSAL/Graph-based `loadFromSharePointExcel` + `applyExcelRecords` logic.
- Ensure form reset, error display strings, disabled T3 when T2 is blank, and accurate summary fields (`totalDays`, `usedDays`, `remainingDays`, `lastUpdated`) update immediately after add/load actions.

### Testing
- Started a local static server with `python -m http.server 8000` and the server ran successfully for manual/automated UI access.
- Captured a full-page screenshot via a Playwright script which completed successfully and produced `artifacts/travel-budget.png` as verification of the rendered UI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc67330108331871832dfa3c8137b)